### PR TITLE
Create community header

### DIFF
--- a/src/components/CommunityProfile/CommunityHeader.css
+++ b/src/components/CommunityProfile/CommunityHeader.css
@@ -1,0 +1,58 @@
+.community-header-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    height: 240px;
+    min-width: 700px;
+    max-width: 800px;
+    padding: 10px;
+}
+
+.community-image-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    align-items: center;
+}
+
+.community-info-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: left;
+    padding: 0 20px 0 20px;
+}
+
+.community-info-title-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: left;
+}
+
+.community-info-name-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
+
+.community-info-button-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 10px;
+}
+
+.community-image {
+    display: block;
+    height: 200px;
+    width: 200px;
+    border-radius: 100%;
+}
+
+.community-button {
+    margin: 0 5px 0 5px;
+}
+

--- a/src/components/CommunityProfile/CommunityHeader.js
+++ b/src/components/CommunityProfile/CommunityHeader.js
@@ -1,12 +1,79 @@
-import React from "react"
-import "./style.css"
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+import { Typography, Button } from "antd"
+import "./CommunityHeader.css"
 
-const CommunityHeader = () => {
-  return (
-    <div className="communityheader">
-      <div />
-    </div>
-  )
+const { Title, Text } = Typography
+
+class CommunityHeader extends Component {
+  // Required props: community (currently placeholder), editable, joinable
+  constructor(props) {
+    super(props)
+    this.state = {
+      /* vvv placeholder information vvv */
+      community: {
+        image:
+          "https://cravingsbychrissyteigen.com/wp-content/uploads/2020/05/CookingWithAlcohol_Square.jpg",
+        name: "ACM Cooking",
+        description:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      },
+      /* ^^^ placeholder information ^^^ */
+      editable: props.editable,
+      joinable: props.joinable,
+    }
+  }
+
+  render() {
+    const {
+      community: { image, name, description },
+      editable,
+      joinable,
+    } = this.state
+
+    const buttons = []
+
+    if (joinable)
+      buttons.push(
+        <Button className="community-button" type="primary" size="large">
+          + Join
+        </Button>
+      )
+    else
+      buttons.push(
+        <Button className="community-button" type="primary" size="large">
+          Leave
+        </Button>
+      )
+
+    if (editable)
+      buttons.push(
+        <Button className="community-button" size="large">
+          Edit Community
+        </Button>
+      )
+    return (
+      <div className="community-header-container">
+        <div className="community-image-container">
+          <img className="community-image" src={image} alt="community" />
+        </div>
+        <div className="community-info-container">
+          <div className="community-info-title-container">
+            <div className="community-info-name-container">
+              <Title level={2}>{name}</Title>
+            </div>
+            <div className="community-info-button-container">{buttons}</div>
+          </div>
+          <Text>{description}</Text>
+        </div>
+      </div>
+    )
+  }
+}
+
+CommunityHeader.propTypes = {
+  joinable: PropTypes.bool.isRequired,
+  editable: PropTypes.bool.isRequired,
 }
 
 export default CommunityHeader

--- a/src/components/CommunityProfile/style.css
+++ b/src/components/CommunityProfile/style.css
@@ -1,3 +1,0 @@
-
-/* CSS for the Community Profile Page */
-


### PR DESCRIPTION
Initial creation of commnity header, to be used on community pages in order to display the community's image, title, and description.

The header also includes buttons to join/leave and edit the community. As of right now these are shown by setting the 'joinable' and 'editable' attribute.
- "Follow" button shows if 'joinable' is true, "Leave" button shows otherwise
- "Edit Community" button shows if 'editable' is true

Information displayed in community header is currently placeholder.