### PR TITLE
Create user header

### DIFF
--- a/src/components/UserProfile/UserHeader.css
+++ b/src/components/UserProfile/UserHeader.css
@@ -1,0 +1,57 @@
+.user-header-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    height: 240px;
+    min-width: 700px;
+    max-width: 800px;
+    padding: 10px;
+}
+
+.user-image-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    align-items: center;
+}
+
+.user-info-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: left;
+    padding: 0 20px 0 20px;
+}
+
+.user-info-title-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: left;
+}
+
+.user-info-name-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
+
+.user-info-button-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 10px;
+}
+
+.user-image {
+    display: block;
+    height: 200px;
+    width: 200px;
+    border-radius: 100%;
+}
+
+.user-button {
+    margin: 0 5px 0 5px;
+}

--- a/src/components/UserProfile/UserHeader.css
+++ b/src/components/UserProfile/UserHeader.css
@@ -32,9 +32,9 @@
 
 .user-info-name-container {
     display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-content: center;
 }
 
 .user-info-button-container {

--- a/src/components/UserProfile/UserHeader.js
+++ b/src/components/UserProfile/UserHeader.js
@@ -1,12 +1,84 @@
-import React from "react"
-import "./style.css"
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+import { Typography, Button } from "antd"
+import "./UserHeader.css"
 
-const UserHeader = () => {
-  return (
-    <div className="userheader">
-      <div />
-    </div>
-  )
+const { Title, Text } = Typography
+
+class UserHeader extends Component {
+  // Required props: user (currently placeholder), editable, joinable
+  constructor(props) {
+    super(props)
+    this.state = {
+      /* vvv placeholder information vvv */
+      user: {
+        image:
+          "https://www.rasmussen.edu/-/media/images/blog/authors/will-erstad.jpg?h=256&w=256&la=en&hash=B22E03E9F3B26AE141E0109114059B8D54B71024",
+        name: "John Doe",
+        major: "Computer Science",
+        year: "2nd",
+        description:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      },
+      /* ^^^ placeholder information ^^^ */
+      editable: props.editable,
+      followable: props.followable,
+    }
+  }
+
+  render() {
+    const {
+      user: { image, name, major, year, description },
+      editable,
+      followable,
+    } = this.state
+
+    const buttons = []
+
+    if (editable)
+      buttons.push(
+        <Button className="user-button" size="large">
+          Edit Profile
+        </Button>
+      )
+    else if (followable)
+      buttons.push(
+        <Button className="user-button" type="primary" size="large">
+          + Follow
+        </Button>
+      )
+    else
+      buttons.push(
+        <Button className="user-button" size="large">
+          - Unfollow
+        </Button>
+      )
+
+    return (
+      <div className="user-header-container">
+        <div className="user-image-container">
+          <img className="user-image" src={image} alt="user" />
+        </div>
+        <div className="user-info-container">
+          <div className="user-info-title-container">
+            <div className="user-info-name-container">
+              <Title level={2}>{name}</Title>
+              <Title level={3}>
+                {year} Year - {major}
+              </Title>
+            </div>
+            <div className="user-info-button-container">{buttons}</div>
+          </div>
+          <Text>{description}</Text>
+        </div>
+      </div>
+    )
+  }
+}
+
+UserHeader.propTypes = {
+  editable: PropTypes.bool.isRequired,
+  followable: PropTypes.bool.isRequired,
 }
 
 export default UserHeader

--- a/src/components/UserProfile/UserHeader.js
+++ b/src/components/UserProfile/UserHeader.js
@@ -62,8 +62,10 @@ class UserHeader extends Component {
         <div className="user-info-container">
           <div className="user-info-title-container">
             <div className="user-info-name-container">
-              <Title level={2}>{name}</Title>
-              <Title level={3}>
+              <Title style={{ margin: 0 }} level={2}>
+                {name}
+              </Title>
+              <Title style={{ margin: 0 }} level={3}>
                 {year} Year - {major}
               </Title>
             </div>

--- a/src/components/UserProfile/style.css
+++ b/src/components/UserProfile/style.css
@@ -1,1 +1,0 @@
-/* CSS for the User Profile Page */


### PR DESCRIPTION
**(Similar to #20)**
Initial creation of user/member header, to be used on user pages in order to display the user's image, title, year, major, and description.

The header also includes buttons to follow/unfollow and edit the user's profile. As of right now these are shown by setting the 'followable' and 'editable' attribute.

"Edit Profile" button shows if 'editable' is true, the follow/unfollow button will not show as it is assumed to be the user themself.
Otherwise, a follow/unfollow button will show

Information displayed in user header is currently placeholder.